### PR TITLE
Receive longer messages.

### DIFF
--- a/boardserver/server.py
+++ b/boardserver/server.py
@@ -79,7 +79,9 @@ class Server(object):
                     self.local.run = False
 
                 elif data.get('state', {}).get('player') == self.local.player:
-                    message = socket.recv(4096)
+                    message = ''
+                    while not message.endswith('\r\n'):
+                        message += socket.recv(4096)
                     messages = message.rstrip().split('\r\n')
                     self.parse(messages[0]) # FIXME: support for multiple messages
                                             #        or out-of-band requests


### PR DESCRIPTION
As requested in jbradberry/boardgame-socketplayer#1, this removes the hard limit of 4096 for message length. It's much less likely to be a problem though, because you only send action messages to the server, not game state.